### PR TITLE
EcoIP-001: Patching VoteCheckpoints, moving ECOxStaking to an upgradable proxy

### DIFF
--- a/contracts/currency/InflationCheckpoints.sol
+++ b/contracts/currency/InflationCheckpoints.sol
@@ -84,7 +84,7 @@ abstract contract InflationCheckpoints is
         returns (uint256)
     {
         require(
-            blockNumber <= block.number,
+            blockNumber < block.number,
             "InflationCheckpoints: block not yet mined"
         );
         return _checkpointsLookup(_linearInflationCheckpoints, blockNumber);

--- a/contracts/currency/InflationCheckpoints.sol
+++ b/contracts/currency/InflationCheckpoints.sol
@@ -84,8 +84,8 @@ abstract contract InflationCheckpoints is
         returns (uint256)
     {
         require(
-            blockNumber < block.number,
-            "InflationCheckpoints: block not yet mined"
+            blockNumber <= block.number,
+            "InflationCheckpoints: cannot check future block"
         );
         return _checkpointsLookup(_linearInflationCheckpoints, blockNumber);
     }

--- a/contracts/currency/README.md
+++ b/contracts/currency/README.md
@@ -154,6 +154,7 @@ Passes through to `getPastVotingGons`. Exists as a virtual function to be overri
 
 ##### Security Notes
  - This is not the same as the user's balance at the time. This is used purely for looking at snapshotted voting power and accounts for the delegation decisions of the `_owner` address.
+ - reverts if called on the current or future blocks
 
 #### getPastVotingGons
 Arguments:
@@ -345,6 +346,7 @@ Overrides the `getPastVotes` function in `VoteCheckpoints` to account for inflat
 ##### Security Notes
  - This is not the same as the user's balance at the time. This is used purely for looking at snapshotted voting power of accounts to account for the delegation decisions of the `account` address.
  - the division is done via deterministic integer division with truncation
+ - still reverts for current and future blocks as with `getPastVotes` in `VoteCheckpoints.sol`
 
 
 ### ECO

--- a/contracts/currency/VoteCheckpoints.sol
+++ b/contracts/currency/VoteCheckpoints.sol
@@ -225,7 +225,7 @@ abstract contract VoteCheckpoints is ERC20Pausable, DelegatePermit {
         returns (uint256)
     {
         require(
-            blockNumber <= block.number,
+            blockNumber < block.number,
             "VoteCheckpoints: block not yet mined"
         );
         return _checkpointsLookup(checkpoints[account], blockNumber);
@@ -245,7 +245,7 @@ abstract contract VoteCheckpoints is ERC20Pausable, DelegatePermit {
         returns (uint256)
     {
         require(
-            blockNumber <= block.number,
+            blockNumber < block.number,
             "VoteCheckpoints: block not yet mined"
         );
         return _checkpointsLookup(_totalSupplyCheckpoints, blockNumber);
@@ -494,6 +494,11 @@ abstract contract VoteCheckpoints is ERC20Pausable, DelegatePermit {
         address to,
         uint256 amount
     ) internal virtual override {
+        if (from == to) {
+            // self transfers require no change in delegation and can be the source of exploits
+            return;
+        }
+
         // if the address has delegated, they might be transfering tokens allotted to someone else
         if (!isOwnDelegate(from)) {
             uint256 _undelegatedAmount = _balances[from] +

--- a/contracts/governance/community/VoteCheckpointsUpgrade.propo.sol
+++ b/contracts/governance/community/VoteCheckpointsUpgrade.propo.sol
@@ -36,7 +36,11 @@ contract VoteCheckpointsUpgrade is Policy, Proposal {
      *
      * @param _newStaking The address of the contract to mark as ECOxStaking.
      */
-    constructor(address _newStaking, address _newECOImpl, address _implementationUpdatingTarget) {
+    constructor(
+        address _newStaking,
+        address _newECOImpl,
+        address _implementationUpdatingTarget
+    ) {
         newStaking = _newStaking;
         newECOImpl = _newECOImpl;
         implementationUpdatingTarget = _implementationUpdatingTarget;
@@ -51,7 +55,8 @@ contract VoteCheckpointsUpgrade is Policy, Proposal {
     /** A short description of the proposal.
      */
     function description() public pure override returns (string memory) {
-        return "Updating ECOxStaking and ECO contracts to patch the voting snapshot and delegation during self-transfers";
+        return
+            "Updating ECOxStaking and ECO contracts to patch the voting snapshot and delegation during self-transfers";
     }
 
     /** A URL where further details can be found.
@@ -65,21 +70,14 @@ contract VoteCheckpointsUpgrade is Policy, Proposal {
      * This is run in the storage context of the root policy contract.
      */
     function enacted(address) public override {
-      // because ECOxStaking isn't proxied yet, we have to move over the identifier
-      setPolicy(
-          ECOxStakingIdentifier,
-          newStaking,
-          PolicyVotesIdentifier
-      );
+        // because ECOxStaking isn't proxied yet, we have to move over the identifier
+        setPolicy(ECOxStakingIdentifier, newStaking, PolicyVotesIdentifier);
 
-      address _ecoProxyAddr = policyFor(ECOIdentifier);
+        address _ecoProxyAddr = policyFor(ECOIdentifier);
 
-      Policed(_ecoProxyAddr).policyCommand(
-          implementationUpdatingTarget,
-          abi.encodeWithSignature(
-              "updateImplementation(address)",
-              newECOImpl
-          )
-      );
+        Policed(_ecoProxyAddr).policyCommand(
+            implementationUpdatingTarget,
+            abi.encodeWithSignature("updateImplementation(address)", newECOImpl)
+        );
     }
 }

--- a/contracts/governance/community/VoteCheckpointsUpgrade.propo.sol
+++ b/contracts/governance/community/VoteCheckpointsUpgrade.propo.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "../../policy/Policy.sol";
+import "../../policy/Policed.sol";
 import "./Proposal.sol";
 
 /** @title VoteCheckpointsUpgrade
@@ -9,16 +10,36 @@ import "./Proposal.sol";
  * A proposal to upgrade the ECO and ECOxStaking contract.
  */
 contract VoteCheckpointsUpgrade is Policy, Proposal {
-    /** The address of the contract to grant backdoor privileges to.
+    /** The address of the contract to denote as ECOxStaking.
      */
     address public immutable newStaking;
+
+    /** The address of the updated ECO implementation contract
+     */
+    address public immutable newECOImpl;
+
+    /** The address of the updating contract
+     */
+    address public immutable implementationUpdatingTarget;
+
+    // The ID hash for the ECO contract
+    bytes32 public constant ECOIdentifier = keccak256("ECO");
+
+    // The ID hash for the ECOxStaking contract
+    bytes32 public constant ECOxStakingIdentifier = keccak256("ECOxStaking");
+
+    // The ID hash for the PolicyVotes contract
+    // this is used for cluing in the use of setPolicy
+    bytes32 public constant PolicyVotesIdentifier = keccak256("PolicyVotes");
 
     /** Instantiate a new proposal.
      *
      * @param _newStaking The address of the contract to mark as ECOxStaking.
      */
-    constructor(address _newStaking) {
+    constructor(address _newStaking, address _newECOImpl, address _implementationUpdatingTarget) {
         newStaking = _newStaking;
+        newECOImpl = _newECOImpl;
+        implementationUpdatingTarget = _implementationUpdatingTarget;
     }
 
     /** The name of the proposal.
@@ -44,11 +65,21 @@ contract VoteCheckpointsUpgrade is Policy, Proposal {
      * This is run in the storage context of the root policy contract.
      */
     function enacted(address) public override {
-      // because ECOxStaking isn't proxied yet, we just move over the identifier
+      // because ECOxStaking isn't proxied yet, we have to move over the identifier
       setPolicy(
-          keccak256("ECOxStaking"),
+          ECOxStakingIdentifier,
           newStaking,
-          keccak256("PolicyVotes")
+          PolicyVotesIdentifier
+      );
+
+      address _ecoProxyAddr = policyFor(ECOIdentifier);
+
+      Policed(_ecoProxyAddr).policyCommand(
+          implementationUpdatingTarget,
+          abi.encodeWithSignature(
+              "updateImplementation(address)",
+              newECOImpl
+          )
       );
     }
 }

--- a/contracts/governance/community/VoteCheckpointsUpgrade.propo.sol
+++ b/contracts/governance/community/VoteCheckpointsUpgrade.propo.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../policy/Policy.sol";
+import "./Proposal.sol";
+
+/** @title VoteCheckpointsUpgrade
+ *
+ * A proposal to upgrade the ECO and ECOxStaking contract.
+ */
+contract VoteCheckpointsUpgrade is Policy, Proposal {
+    /** The address of the contract to grant backdoor privileges to.
+     */
+    address public immutable newStaking;
+
+    /** Instantiate a new proposal.
+     *
+     * @param _newStaking The address of the contract to mark as ECOxStaking.
+     */
+    constructor(address _newStaking) {
+        newStaking = _newStaking;
+    }
+
+    /** The name of the proposal.
+     */
+    function name() public pure override returns (string memory) {
+        return "VoteCheckpointsUpgrade";
+    }
+
+    /** A short description of the proposal.
+     */
+    function description() public pure override returns (string memory) {
+        return "Change the ECO and ECOxStaking contract";
+    }
+
+    /** A URL where further details can be found.
+     */
+    function url() public pure override returns (string memory) {
+        return "probably not using this";
+    }
+
+    /** Enact the proposal.
+     *
+     * This is run in the storage context of the root policy contract.
+     */
+    function enacted(address) public override {
+      // because ECOxStaking isn't proxied yet, we just move over the identifier
+      setPolicy(
+          keccak256("ECOxStaking"),
+          newStaking,
+          keccak256("PolicyVotes")
+      );
+    }
+}

--- a/contracts/governance/community/VoteCheckpointsUpgrade.propo.sol
+++ b/contracts/governance/community/VoteCheckpointsUpgrade.propo.sol
@@ -45,19 +45,19 @@ contract VoteCheckpointsUpgrade is Policy, Proposal {
     /** The name of the proposal.
      */
     function name() public pure override returns (string memory) {
-        return "VoteCheckpointsUpgrade";
+        return "Update to VoteCheckpoints";
     }
 
     /** A short description of the proposal.
      */
     function description() public pure override returns (string memory) {
-        return "Change the ECO and ECOxStaking contract";
+        return "Updating ECOxStaking and ECO contracts to patch the voting snapshot and delegation during self-transfers";
     }
 
     /** A URL where further details can be found.
      */
     function url() public pure override returns (string memory) {
-        return "probably not using this";
+        return "none";
     }
 
     /** Enact the proposal.

--- a/contracts/test/InfiniteVote.sol
+++ b/contracts/test/InfiniteVote.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./Subvoter.sol";
+import "../currency/ECO.sol";
+import "../governance/community/PolicyProposals.sol";
+import "../governance/community/PolicyVotes.sol";
+import "../governance/community/Proposal.sol";
+import "../governance/TimedPolicies.sol";
+import "../policy/Policy.sol";
+
+
+contract InfiniteVote{
+
+    Subvoter[] public subvoters;
+
+    uint256 public immutable NUM_SUBVOTERS;
+
+    uint256 public constant COST_REGISTER = 10000e18;
+
+    address public immutable PROPOSAL;
+
+    ECO public immutable ecoaddress;
+
+    constructor(uint256 _num_subvoters, ECO _ecoaddress, address _proposal){
+        NUM_SUBVOTERS = _num_subvoters;
+        ecoaddress = _ecoaddress;
+        PROPOSAL = _proposal;
+
+        for (uint256 i = 0; i < NUM_SUBVOTERS*11/3; i++) {
+            subvoters.push(
+                new Subvoter(ecoaddress)
+            );
+        }
+    }
+
+    function infiniteVote(TimedPolicies timed, Policy policy) external {
+        timed.incrementGeneration();
+        PolicyProposals policyprops = PolicyProposals(policy.policyFor(keccak256("PolicyProposals")));
+        ecoaddress.approve(address(policyprops), COST_REGISTER);
+        policyprops.registerProposal(Proposal(PROPOSAL));
+        for (uint256 i = 0; i < NUM_SUBVOTERS; i++) {
+            ecoaddress.transfer(address(subvoters[i]), ecoaddress.balanceOf(address(this)));
+            subvoters[i].votePolicy(policyprops, PROPOSAL);
+        }
+        policyprops.deployProposalVoting();
+        PolicyVotes policyvotes = PolicyVotes(policy.policyFor(keccak256("PolicyVotes")));
+        for (uint256 i = 0; i < NUM_SUBVOTERS*11/3; i++) {
+            ecoaddress.transfer(address(subvoters[i]), ecoaddress.balanceOf(address(this)));
+            subvoters[i].voteVotes(policyvotes);
+        }
+    }
+
+}

--- a/contracts/test/InfiniteVote.sol
+++ b/contracts/test/InfiniteVote.sol
@@ -9,9 +9,7 @@ import "../governance/community/Proposal.sol";
 import "../governance/TimedPolicies.sol";
 import "../policy/Policy.sol";
 
-
-contract InfiniteVote{
-
+contract InfiniteVote {
     Subvoter[] public subvoters;
 
     uint256 public immutable NUM_SUBVOTERS;
@@ -22,33 +20,44 @@ contract InfiniteVote{
 
     ECO public immutable ecoaddress;
 
-    constructor(uint256 _num_subvoters, ECO _ecoaddress, address _proposal){
+    constructor(
+        uint256 _num_subvoters,
+        ECO _ecoaddress,
+        address _proposal
+    ) {
         NUM_SUBVOTERS = _num_subvoters;
         ecoaddress = _ecoaddress;
         PROPOSAL = _proposal;
 
-        for (uint256 i = 0; i < NUM_SUBVOTERS*11/3; i++) {
-            subvoters.push(
-                new Subvoter(ecoaddress)
-            );
+        for (uint256 i = 0; i < (NUM_SUBVOTERS * 11) / 3; i++) {
+            subvoters.push(new Subvoter(ecoaddress));
         }
     }
 
     function infiniteVote(TimedPolicies timed, Policy policy) external {
         timed.incrementGeneration();
-        PolicyProposals policyprops = PolicyProposals(policy.policyFor(keccak256("PolicyProposals")));
+        PolicyProposals policyprops = PolicyProposals(
+            policy.policyFor(keccak256("PolicyProposals"))
+        );
         ecoaddress.approve(address(policyprops), COST_REGISTER);
         policyprops.registerProposal(Proposal(PROPOSAL));
         for (uint256 i = 0; i < NUM_SUBVOTERS; i++) {
-            ecoaddress.transfer(address(subvoters[i]), ecoaddress.balanceOf(address(this)));
+            ecoaddress.transfer(
+                address(subvoters[i]),
+                ecoaddress.balanceOf(address(this))
+            );
             subvoters[i].votePolicy(policyprops, PROPOSAL);
         }
         policyprops.deployProposalVoting();
-        PolicyVotes policyvotes = PolicyVotes(policy.policyFor(keccak256("PolicyVotes")));
-        for (uint256 i = 0; i < NUM_SUBVOTERS*11/3; i++) {
-            ecoaddress.transfer(address(subvoters[i]), ecoaddress.balanceOf(address(this)));
+        PolicyVotes policyvotes = PolicyVotes(
+            policy.policyFor(keccak256("PolicyVotes"))
+        );
+        for (uint256 i = 0; i < (NUM_SUBVOTERS * 11) / 3; i++) {
+            ecoaddress.transfer(
+                address(subvoters[i]),
+                ecoaddress.balanceOf(address(this))
+            );
             subvoters[i].voteVotes(policyvotes);
         }
     }
-
 }

--- a/contracts/test/PoodleECO.sol
+++ b/contracts/test/PoodleECO.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../currency/ECO.sol";
+
+/** @title Proxy Upgrading Process
+ *
+ * This contract is used to show how the upgrade process can replace a proxied contract.
+ * It only adds functionality to confirm that the contract is replaced. The underlying contract is
+ * proxied to retain complex long term data. A change in the implementer of the ForwardProxy is all that's needed, however.
+ */
+contract PoodleECO is ECO {
+    constructor(Policy _policy)
+        ECO(_policy, address(1), 2, address(3))
+    {
+      // the distributor and initial supply are unneeded going forward, but could be preserved (are immutable)
+      // the initial pauser is a mutable variable and therefore is already in storage for the proxy
+      // setting the value here proves that the initialize function isn't called to clobber the previous pauser
+    }
+
+    function provePoodles() public pure returns (bool) {
+        return true;
+    }
+}

--- a/contracts/test/PoodleECO.sol
+++ b/contracts/test/PoodleECO.sol
@@ -10,12 +10,10 @@ import "../currency/ECO.sol";
  * proxied to retain complex long term data. A change in the implementer of the ForwardProxy is all that's needed, however.
  */
 contract PoodleECO is ECO {
-    constructor(Policy _policy)
-        ECO(_policy, address(1), 2, address(3))
-    {
-      // the distributor and initial supply are unneeded going forward, but could be preserved (are immutable)
-      // the initial pauser is a mutable variable and therefore is already in storage for the proxy
-      // setting the value here proves that the initialize function isn't called to clobber the previous pauser
+    constructor(Policy _policy) ECO(_policy, address(1), 2, address(3)) {
+        // the distributor and initial supply are unneeded going forward, but could be preserved (are immutable)
+        // the initial pauser is a mutable variable and therefore is already in storage for the proxy
+        // setting the value here proves that the initialize function isn't called to clobber the previous pauser
     }
 
     function provePoodles() public pure returns (bool) {

--- a/contracts/test/PoodlexStaking.sol
+++ b/contracts/test/PoodlexStaking.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../governance/community/ECOxStaking.sol";
+
+/** @title Identifier Upgrading Process
+ *
+ * This contract is used to show how the upgrade process can move a contract identifier.
+ * It only adds functionality to confirm that the contract is replaced.
+ */
+contract PoodlexStaking is ECOxStaking {
+    constructor(Policy _policy, IERC20 _ecoXAddr)
+        ECOxStaking(_policy, _ecoXAddr)
+    {}
+
+    function provePoodles() public pure returns (bool) {
+        return true;
+    }
+}

--- a/contracts/test/Subvoter.sol
+++ b/contracts/test/Subvoter.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../currency/ECO.sol";
+import "../governance/community/PolicyProposals.sol";
+import "../governance/community/PolicyVotes.sol";
+import "../governance/community/Proposal.sol";
+
+contract Subvoter{
+
+    ECO public immutable ecoaddress;
+
+    constructor(ECO _ecoaddress){
+        ecoaddress = _ecoaddress;
+    }
+
+    function votePolicy(PolicyProposals _proposals, address _proposalToSupport) public {
+        _proposals.support(Proposal(_proposalToSupport));
+        ecoaddress.transfer(msg.sender, ecoaddress.balanceOf(address(this)));
+    }
+
+    function voteVotes(PolicyVotes _votes) public {
+        _votes.vote(true);
+        ecoaddress.transfer(msg.sender, ecoaddress.balanceOf(address(this)));
+    }
+
+}

--- a/contracts/test/Subvoter.sol
+++ b/contracts/test/Subvoter.sol
@@ -6,15 +6,16 @@ import "../governance/community/PolicyProposals.sol";
 import "../governance/community/PolicyVotes.sol";
 import "../governance/community/Proposal.sol";
 
-contract Subvoter{
-
+contract Subvoter {
     ECO public immutable ecoaddress;
 
-    constructor(ECO _ecoaddress){
+    constructor(ECO _ecoaddress) {
         ecoaddress = _ecoaddress;
     }
 
-    function votePolicy(PolicyProposals _proposals, address _proposalToSupport) public {
+    function votePolicy(PolicyProposals _proposals, address _proposalToSupport)
+        public
+    {
         _proposals.support(Proposal(_proposalToSupport));
         ecoaddress.transfer(msg.sender, ecoaddress.balanceOf(address(this)));
     }
@@ -23,5 +24,4 @@ contract Subvoter{
         _votes.vote(true);
         ecoaddress.transfer(msg.sender, ecoaddress.balanceOf(address(this)));
     }
-
 }

--- a/supervisor/inflationGovernor.ts
+++ b/supervisor/inflationGovernor.ts
@@ -193,11 +193,7 @@ export class InflationGovernor {
     console.log('trying to commit vdf seed')
 
     let primalNumber: number = 0
-    primalNumber = await getPrimal(
-      (
-        await fetchLatestBlock(this.provider)
-      ).hash
-    )
+    primalNumber = await getPrimal((await fetchLatestBlock(this.provider)).hash)
     console.log('got primal')
     try {
       tx = await this.randomInflation.setPrimal(primalNumber)

--- a/supervisor/tools.ts
+++ b/supervisor/tools.ts
@@ -1,19 +1,21 @@
 import { logError, SupervisorError } from './logError'
 import * as ethers from 'ethers'
 
-export const fetchLatestBlock = async (provider: ethers.providers.BaseProvider) => {
-    let errors: any = []
-    for (let i = 0; i < 3; i++) {
-      try {
-        return await provider.getBlock('latest')
-      } catch (e) {
-        errors.push(e)
-        continue
-      }
+export const fetchLatestBlock = async (
+  provider: ethers.providers.BaseProvider
+) => {
+  const errors: any = []
+  for (let i = 0; i < 3; i++) {
+    try {
+      return await provider.getBlock('latest')
+    } catch (e) {
+      errors.push(e)
+      continue
     }
-    logError({
-      type: SupervisorError.InfuraIssue,
-      error: errors
-    })
-    throw new Error('Infura Issue')
   }
+  logError({
+    type: SupervisorError.InfuraIssue,
+    error: errors,
+  })
+  throw new Error('Infura Issue')
+}

--- a/test/currency/ECO.js
+++ b/test/currency/ECO.js
@@ -1776,7 +1776,7 @@ describe('ECO [@group=1]', () => {
         )
       })
 
-      it.only('no exploit on self transfer', async () => {
+      it('no exploit on self transfer', async () => {
         await eco.connect(accounts[2]).delegate(await accounts[3].getAddress())
         await eco
           .connect(accounts[1])

--- a/test/currency/ECO.js
+++ b/test/currency/ECO.js
@@ -997,10 +997,7 @@ describe('ECO [@group=1]', () => {
       await expect(
         eco
           .connect(from)
-          .getPastVotingGons(
-            await from.getAddress(),
-            (await time.latestBlock())
-          )
+          .getPastVotingGons(await from.getAddress(), await time.latestBlock())
       ).to.be.revertedWith(
         'VoteCheckpoints: block not yet mined',
         eco.constructor
@@ -1009,7 +1006,7 @@ describe('ECO [@group=1]', () => {
 
     it('cannot get the past supply until the block requestsed has been mined', async () => {
       await expect(
-        eco.connect(from).getPastTotalSupply((await time.latestBlock()))
+        eco.connect(from).getPastTotalSupply(await time.latestBlock())
       ).to.be.revertedWith(
         'VoteCheckpoints: block not yet mined',
         eco.constructor
@@ -1781,18 +1778,37 @@ describe('ECO [@group=1]', () => {
         await eco
           .connect(accounts[1])
           .delegateAmount(await accounts[2].getAddress(), voteAmount.div(4))
-        await eco.connect(accounts[2]).transfer(await accounts[2].getAddress(), amount.div(4))
+        await eco
+          .connect(accounts[2])
+          .transfer(await accounts[2].getAddress(), amount.div(4))
 
         await time.advanceBlock()
 
-        expect(await eco.getPastVotes(await accounts[1].getAddress(), await time.latestBlock() - 1)).to.equal(amount.mul(3).div(4))
-        expect(await eco.getPastVotes(await accounts[2].getAddress(), await time.latestBlock() - 1)).to.equal(amount.div(4))
-        expect(await eco.getPastVotes(await accounts[3].getAddress(), await time.latestBlock() - 1)).to.equal(amount.mul(2))
+        expect(
+          await eco.getPastVotes(
+            await accounts[1].getAddress(),
+            (await time.latestBlock()) - 1
+          )
+        ).to.equal(amount.mul(3).div(4))
+        expect(
+          await eco.getPastVotes(
+            await accounts[2].getAddress(),
+            (await time.latestBlock()) - 1
+          )
+        ).to.equal(amount.div(4))
+        expect(
+          await eco.getPastVotes(
+            await accounts[3].getAddress(),
+            (await time.latestBlock()) - 1
+          )
+        ).to.equal(amount.mul(2))
 
         await eco
           .connect(accounts[1])
           .undelegateFromAddress(await accounts[2].getAddress())
-        await eco.connect(accounts[1]).transfer(await accounts[2].getAddress(), amount)
+        await eco
+          .connect(accounts[1])
+          .transfer(await accounts[2].getAddress(), amount)
       })
     })
 

--- a/test/currency/IECO.js
+++ b/test/currency/IECO.js
@@ -239,7 +239,7 @@ describe('IECO [@group=5]', () => {
     it('Cannot return future balances', async () => {
       await expect(
         eco.getPastVotes(await accounts[1].getAddress(), 999999999)
-      ).to.be.revertedWith('InflationCheckpoints: block not yet mined')
+      ).to.be.revertedWith('InflationCheckpoints: cannot check future block')
     })
 
     context('after a long time', () => {

--- a/test/governance/FirstTrusteeElection.js
+++ b/test/governance/FirstTrusteeElection.js
@@ -113,7 +113,6 @@ describe('E2E Election of First Cohort and Funding of TrustedNodes [@group=9]', 
   })
 
   it('Adds stake to the proposal to ensure it goes to a vote', async () => {
-    await policyProposals.connect(alice).support(trusteeReplacement.address)
     await policyProposals.connect(bob).support(trusteeReplacement.address)
     await policyProposals.connect(bob).deployProposalVoting()
   })

--- a/test/governance/Lockup.js
+++ b/test/governance/Lockup.js
@@ -311,25 +311,27 @@ describe('Lockup [@group=3]', () => {
     })
 
     it('lockup has no voting power', async () => {
+      await time.advanceBlock()
       const lockupPower = await eco.getPastVotes(
         lockup.address,
-        await time.latestBlock()
+        (await time.latestBlock()) - 1
       )
       expect(lockupPower).to.equal(0)
     })
 
     it('users have correct voting power', async () => {
+      await time.advanceBlock()
       const alicePower = await eco.getPastVotes(
         alice.address,
-        await time.latestBlock()
+        (await time.latestBlock()) - 1
       )
       const bobPower = await eco.getPastVotes(
         bob.address,
-        await time.latestBlock()
+        (await time.latestBlock()) - 1
       )
       const charliePower = await eco.getPastVotes(
         charlie.address,
-        await time.latestBlock()
+        (await time.latestBlock()) - 1
       )
 
       expect(alicePower).to.equal(5000000000)
@@ -344,17 +346,18 @@ describe('Lockup [@group=3]', () => {
       })
 
       it('lockup power stays, unlocked power moves', async () => {
+        await time.advanceBlock()
         const alicePower = await eco.getPastVotes(
           alice.address,
-          await time.latestBlock()
+          (await time.latestBlock()) - 1
         )
         const bobPower = await eco.getPastVotes(
           bob.address,
-          await time.latestBlock()
+          (await time.latestBlock()) - 1
         )
         const charliePower = await eco.getPastVotes(
           charlie.address,
-          await time.latestBlock()
+          (await time.latestBlock()) - 1
         )
 
         expect(alicePower).to.equal(3000000000)
@@ -365,18 +368,19 @@ describe('Lockup [@group=3]', () => {
       it('nonintuitive behavior fixes when bob withdraws', async () => {
         await time.increase(3600 * 24 * 21.1)
         await lockup.connect(bob).withdraw()
+        await time.advanceBlock()
 
         const alicePower = await eco.getPastVotes(
           alice.address,
-          await time.latestBlock()
+          (await time.latestBlock()) - 1
         )
         const bobPower = await eco.getPastVotes(
           bob.address,
-          await time.latestBlock()
+          (await time.latestBlock()) - 1
         )
         const charliePower = await eco.getPastVotes(
           charlie.address,
-          await time.latestBlock()
+          (await time.latestBlock()) - 1
         )
 
         expect(alicePower).to.equal(2000000000)

--- a/test/governance/multivote.js
+++ b/test/governance/multivote.js
@@ -1,0 +1,85 @@
+const { expect } = require('chai')
+
+const time = require('../utils/time.ts')
+const { ecoFixture } = require('../utils/fixtures')
+const { deploy } = require('../utils/contracts')
+
+describe('PolicyVotes [@group=8]', () => {
+  let policy
+  let eco
+  let ecox
+  let initInflation
+  let policyVotes
+  let proposal
+  let timedPolicies
+  const one = ethers.utils.parseEther('1')
+
+  let alice
+  let bob
+  let charlie
+  let dave
+  let frank
+
+  const multiplier = 20
+  const multiAmount = one.mul(1500).add(1)
+
+  beforeEach(async () => {
+    const accounts = await ethers.getSigners()
+    ;[alice, bob, charlie, dave, frank] = accounts
+    ;({
+      policy,
+      eco,
+      faucet: initInflation,
+      timedPolicies,
+      ecox,
+    } = await ecoFixture([]))
+
+    await ecox.exchange(await ecox.balanceOf(await alice.getAddress()))
+    await eco.burn(await alice.getAddress(), await eco.balanceOf(await alice.getAddress()))
+
+    await initInflation.mint(await alice.getAddress(), one.mul(50000))
+    await initInflation.mint(await bob.getAddress(), one.mul(50000))
+    await initInflation.mint(await charlie.getAddress(), one.mul(52000))
+    await initInflation.mint(await dave.getAddress(), one.mul(48000))
+
+    proposal = await deploy('SampleProposal', 1)
+
+    await time.increase(3600 * 24 * 14)
+    // await timedPolicies.incrementGeneration()
+  })
+
+  it('cannot multivote', async () => {
+    const multivoter = await deploy('InfiniteVote', multiplier, eco.address, proposal.address)
+    await eco.connect(bob).transfer(multivoter.address, multiAmount.add(one.mul(10000)))
+    await expect(multivoter.infiniteVote(timedPolicies.address, policy.address)).to.be.reverted
+
+    // policyVotes = await ethers.getContractAt(
+    //   'PolicyVotes',await policy.policyFor(ethers.utils.solidityKeccak256(
+    //   ['string'],
+    //   ['PolicyVotes']
+    // )))
+
+    // expect(await policyVotes.yesStake()).to.be.equal(multiAmount.mul(Math.floor(multiplier*11/3)))
+  })
+
+  // it('multivote gas', async () => {
+  //   const multivoter = await deploy('InfiniteVote', multiplier, eco.address, proposal.address)
+  //   await eco.connect(bob).transfer(multivoter.address, multiAmount.add(one.mul(10000)))
+  //   const gas = await multivoter.estimateGas.infiniteVote(timedPolicies.address, policy.address)
+  //   console.log(gas)
+  // })
+
+  // it('multivoting can pass a proposal', async () => {
+  //   const multivoter = await deploy('InfiniteVote', multiplier, eco.address, proposal.address)
+  //   await eco.connect(bob).transfer(multivoter.address, multiAmount.add(one.mul(10000)))
+  //   await multivoter.infiniteVote(timedPolicies.address, policy.address)
+
+  //   policyVotes = await ethers.getContractAt(
+  //     'PolicyVotes',await policy.policyFor(ethers.utils.solidityKeccak256(
+  //     ['string'],
+  //     ['PolicyVotes']
+  //   )))
+
+  //   await policyVotes.execute()
+  // })
+})

--- a/test/governance/multivote.js
+++ b/test/governance/multivote.js
@@ -9,7 +9,6 @@ describe('PolicyVotes [@group=8]', () => {
   let eco
   let ecox
   let initInflation
-  let policyVotes
   let proposal
   let timedPolicies
   const one = ethers.utils.parseEther('1')
@@ -18,14 +17,13 @@ describe('PolicyVotes [@group=8]', () => {
   let bob
   let charlie
   let dave
-  let frank
 
   const multiplier = 20
   const multiAmount = one.mul(1500).add(1)
 
   beforeEach(async () => {
     const accounts = await ethers.getSigners()
-    ;[alice, bob, charlie, dave, frank] = accounts
+    ;[alice, bob, charlie, dave] = accounts
     ;({
       policy,
       eco,
@@ -35,7 +33,10 @@ describe('PolicyVotes [@group=8]', () => {
     } = await ecoFixture([]))
 
     await ecox.exchange(await ecox.balanceOf(await alice.getAddress()))
-    await eco.burn(await alice.getAddress(), await eco.balanceOf(await alice.getAddress()))
+    await eco.burn(
+      await alice.getAddress(),
+      await eco.balanceOf(await alice.getAddress())
+    )
 
     await initInflation.mint(await alice.getAddress(), one.mul(50000))
     await initInflation.mint(await bob.getAddress(), one.mul(50000))
@@ -49,9 +50,17 @@ describe('PolicyVotes [@group=8]', () => {
   })
 
   it('cannot multivote', async () => {
-    const multivoter = await deploy('InfiniteVote', multiplier, eco.address, proposal.address)
-    await eco.connect(bob).transfer(multivoter.address, multiAmount.add(one.mul(10000)))
-    await expect(multivoter.infiniteVote(timedPolicies.address, policy.address)).to.be.reverted
+    const multivoter = await deploy(
+      'InfiniteVote',
+      multiplier,
+      eco.address,
+      proposal.address
+    )
+    await eco
+      .connect(bob)
+      .transfer(multivoter.address, multiAmount.add(one.mul(10000)))
+    await expect(multivoter.infiniteVote(timedPolicies.address, policy.address))
+      .to.be.reverted
 
     // policyVotes = await ethers.getContractAt(
     //   'PolicyVotes',await policy.policyFor(ethers.utils.solidityKeccak256(

--- a/test/governance/upgradeVoteCheckpoints.js
+++ b/test/governance/upgradeVoteCheckpoints.js
@@ -105,7 +105,7 @@ describe('E2E Proxied Contract Upgrade [@group=9]', () => {
       implementationUpdatingTarget.address,
     )
     const name = await makePoodlexStaking.name()
-    expect(name).to.equal('VoteCheckpointsUpgrade')
+    expect(name).to.equal('Update to VoteCheckpoints')
   })
 
   it('Find the policy proposals instance', async () => {
@@ -199,5 +199,6 @@ describe('E2E Proxied Contract Upgrade [@group=9]', () => {
     expect(await newECO.balanceOf(bob.getAddress())).to.equal(stake)
     expect(await newECO.balanceOf(charlie.getAddress())).to.equal(stake)
     expect(await newECO.balanceOf(dave.getAddress())).to.equal(stake)
+    expect(await newECO.totalSupply()).to.equal(stake.mul(4))
   })
 })

--- a/test/governance/upgradeVoteCheckpoints.js
+++ b/test/governance/upgradeVoteCheckpoints.js
@@ -26,13 +26,15 @@ describe('E2E Proxied Contract Upgrade [@group=9]', () => {
   let ecoXStaking
   let makePoodlexStaking
   let poodleCheck
-  let retryPoodleCheckAddress
+  let retryPoodleCheck
 
   let alice
   let bob
   let charlie
   let dave
   let trustedNodes
+
+  const staked = ethers.utils.parseEther('50')
 
   before('Deploys the production system', async () => {
     const accounts = await ethers.getSigners()
@@ -77,6 +79,11 @@ describe('E2E Proxied Contract Upgrade [@group=9]', () => {
     // the contract at ID_ECOXSTAKING is not poodles so it does not have this function
     expect(poodleCheck.address).to.equal(ecoXStaking.address)
     await expect(poodleCheck.provePoodles()).to.be.reverted
+  })
+
+  it('stakes ECOx on current staking contract', async () => {
+    await ecox.connect(alice).approve(ecoXStaking.address, staked)
+    await ecoXStaking.connect(alice).deposit(staked)
   })
 
   it('Constructs the proposal', async () => {

--- a/test/governance/upgradeVoteCheckpoints.js
+++ b/test/governance/upgradeVoteCheckpoints.js
@@ -25,6 +25,7 @@ describe('E2E Proxied Contract Upgrade [@group=9]', () => {
 
   let ecoXStaking
   let poodlexStaking
+  let poodleECO
   let proxyPoodlexStaking
   let makePoodlexStaking
   let newECOxStaking
@@ -92,9 +93,16 @@ describe('E2E Proxied Contract Upgrade [@group=9]', () => {
   })
 
   it('Constructs the proposal', async () => {
-    poodlexStaking = await deploy('PoodlexStaking', policy.address, ecox.address)
-    forwardProxy = await deploy('ForwardProxy', poodlexStaking.address)
-    proxyPoodlexStaking = await ethers.getContractAt('PoodlexStaking', forwardProxy.address)
+    poodlexStaking = await deploy(
+      'PoodlexStaking',
+      policy.address,
+      ecox.address
+    )
+    const forwardProxy = await deploy('ForwardProxy', poodlexStaking.address)
+    proxyPoodlexStaking = await ethers.getContractAt(
+      'PoodlexStaking',
+      forwardProxy.address
+    )
     expect(proxyPoodlexStaking.address).to.equal(forwardProxy.address)
     poodleECO = await deploy('PoodleECO', policy.address)
     implementationUpdatingTarget = await deploy('ImplementationUpdatingTarget')
@@ -102,7 +110,7 @@ describe('E2E Proxied Contract Upgrade [@group=9]', () => {
       'VoteCheckpointsUpgrade',
       proxyPoodlexStaking.address,
       poodleECO.address,
-      implementationUpdatingTarget.address,
+      implementationUpdatingTarget.address
     )
     const name = await makePoodlexStaking.name()
     expect(name).to.equal('Update to VoteCheckpoints')
@@ -163,18 +171,27 @@ describe('E2E Proxied Contract Upgrade [@group=9]', () => {
   // })
 
   it('Checks that the ecoxstaking address has changed', async () => {
-    const stakingHash = ethers.utils.solidityKeccak256(['string'], ['ECOxStaking'])
+    const stakingHash = ethers.utils.solidityKeccak256(
+      ['string'],
+      ['ECOxStaking']
+    )
     newECOxStaking = await ethers.getContractAt(
-      'PoodlexStaking', await policyFor(policy, stakingHash))
+      'PoodlexStaking',
+      await policyFor(policy, stakingHash)
+    )
     expect(newECOxStaking.address).to.not.equal(ecoXStaking.address)
     expect(newECOxStaking.address).to.equal(proxyPoodlexStaking.address)
-    expect(await newECOxStaking.implementation()).to.equal(poodlexStaking.address)
+    expect(await newECOxStaking.implementation()).to.equal(
+      poodlexStaking.address
+    )
   })
 
   it('Checks that the ECO address is the same', async () => {
     const ecoHash = ethers.utils.solidityKeccak256(['string'], ['ECO'])
     newECO = await ethers.getContractAt(
-      'PoodleECO', await policyFor(policy, ecoHash))
+      'PoodleECO',
+      await policyFor(policy, ecoHash)
+    )
     expect(newECO.address).to.equal(eco.address)
   })
 
@@ -194,8 +211,12 @@ describe('E2E Proxied Contract Upgrade [@group=9]', () => {
 
   it('verifies that the ECO contract is as expected', async () => {
     expect(await newECO.implementation()).to.equal(poodleECO.address)
-    expect(await newECO.pauser()).to.equal('0xDEADBEeFbAdf00dC0fFee1Ceb00dAFACEB00cEc0')
-    expect(await newECO.balanceOf(alice.getAddress())).to.equal(stake.sub(await policyProposals.COST_REGISTER()))
+    expect(await newECO.pauser()).to.equal(
+      '0xDEADBEeFbAdf00dC0fFee1Ceb00dAFACEB00cEc0'
+    )
+    expect(await newECO.balanceOf(alice.getAddress())).to.equal(
+      stake.sub(await policyProposals.COST_REGISTER())
+    )
     expect(await newECO.balanceOf(bob.getAddress())).to.equal(stake)
     expect(await newECO.balanceOf(charlie.getAddress())).to.equal(stake)
     expect(await newECO.balanceOf(dave.getAddress())).to.equal(stake)

--- a/test/governance/upgradeVoteCheckpoints.js
+++ b/test/governance/upgradeVoteCheckpoints.js
@@ -1,0 +1,157 @@
+/*
+ * This is an end-to-end demo of the proposal: VoteCheckpointsUpgrade.propo.sol
+ * The ECO contract is getting an upgraded implementation for the proxy
+ * The ECOxStaking contract identifier is getting moved to a new contract (which is proxied)
+ *
+ * Note that this 'test' shares states between the it() functions, and
+ * it() is used mostly to break up the logical steps.
+ *
+ * The purpose of this demo is to help confirm the correct function of the proposal
+ */
+
+const { expect } = require('chai')
+const time = require('../utils/time.ts')
+const { ecoFixture, policyFor } = require('../utils/fixtures')
+const { deploy } = require('../utils/contracts')
+
+describe('E2E Proxied Contract Upgrade [@group=9]', () => {
+  let policy
+  let eco
+  let ecox
+  let timedPolicies
+  let policyProposals
+  let policyVotes
+  let initInflation
+
+  let ecoXStaking
+  let makePoodlexStaking
+  let poodleCheck
+  let retryPoodleCheckAddress
+
+  let alice
+  let bob
+  let charlie
+  let dave
+  let trustedNodes
+
+  before('Deploys the production system', async () => {
+    const accounts = await ethers.getSigners()
+    ;[alice, bob, charlie, dave] = accounts
+    trustedNodes = [
+      await bob.getAddress(),
+      await charlie.getAddress(),
+      await dave.getAddress(),
+    ]
+    ;({
+      policy,
+      eco,
+      ecox,
+      ecoXStaking,
+      faucet: initInflation,
+      timedPolicies,
+    } = await ecoFixture(trustedNodes))
+  })
+
+  it('Stakes accounts', async () => {
+    const stake = ethers.utils.parseEther('5000000')
+    await initInflation.mint(await alice.getAddress(), stake)
+    await initInflation.mint(await bob.getAddress(), stake)
+    await initInflation.mint(await charlie.getAddress(), stake)
+    await initInflation.mint(await dave.getAddress(), stake)
+  })
+
+  it('Waits a generation', async () => {
+    await time.increase(3600 * 24 * 14)
+    await timedPolicies.incrementGeneration()
+  })
+
+  it('Checks that the current staking contract is not poodles', async () => {
+    poodleCheck = await ethers.getContractAt(
+      'PoodlexStaking',
+      await policyFor(
+        policy,
+        ethers.utils.solidityKeccak256(['string'], ['ECOxStaking'])
+      )
+    )
+
+    // the contract at ID_ECOXSTAKING is not poodles so it does not have this function
+    expect(poodleCheck.address).to.equal(ecoXStaking.address)
+    await expect(poodleCheck.provePoodles()).to.be.reverted
+  })
+
+  it('Constructs the proposal', async () => {
+    poodlexStaking = await deploy('PoodlexStaking', policy.address, ecox.address)
+    makePoodlexStaking = await deploy(
+      'VoteCheckpointsUpgrade',
+      poodlexStaking.address,
+    )
+    const name = await makePoodlexStaking.name()
+    expect(name).to.equal('VoteCheckpointsUpgrade')
+  })
+
+  it('Find the policy proposals instance', async () => {
+    const proposalsHash = ethers.utils.solidityKeccak256(
+      ['string'],
+      ['PolicyProposals']
+    )
+    policyProposals = await ethers.getContractAt(
+      'PolicyProposals',
+      await policyFor(policy, proposalsHash)
+    )
+  })
+
+  it('Accepts new proposals', async () => {
+    await eco
+      .connect(alice)
+      .approve(policyProposals.address, await policyProposals.COST_REGISTER())
+    await policyProposals
+      .connect(alice)
+      .registerProposal(makePoodlexStaking.address)
+  })
+
+  it('Adds stake to the proposal to ensure it goes to a vote', async () => {
+    await policyProposals.connect(bob).support(makePoodlexStaking.address)
+    await policyProposals.connect(bob).deployProposalVoting()
+  })
+
+  it('Find the policy votes instance', async () => {
+    const policyVotesIdentifierHash = ethers.utils.solidityKeccak256(
+      ['string'],
+      ['PolicyVotes']
+    )
+    policyVotes = await ethers.getContractAt(
+      'PolicyVotes',
+      await policyFor(policy, policyVotesIdentifierHash)
+    )
+  })
+
+  it('Allows all users to vote', async () => {
+    await policyVotes.connect(alice).vote(true)
+    await policyVotes.connect(bob).vote(true)
+  })
+
+  it('Waits until the end of the voting period', async () => {
+    await time.increase(3600 * 24 * 4)
+  })
+
+  it('Executes the outcome of the votes', async () => {
+    await policyVotes.execute()
+  })
+
+  // it('Moves to the next generation', async () => {
+  //   await time.increase(3600 * 24 * 10)
+  //   await timedPolicies.incrementGeneration()
+  // })
+
+  it('Checks that the address has changed', async () => {
+    const stakingHash = ethers.utils.solidityKeccak256(['string'], ['ECOxStaking'])
+    retryPoodleCheck = await ethers.getContractAt(
+      'PoodlexStaking', await policyFor(policy, stakingHash))
+    expect(retryPoodleCheck).to.not.equal(ecoXStaking.address)
+  })
+
+  it('Checks that the new staking contract is poodles', async () => {
+    const poodles = await retryPoodleCheck.provePoodles()
+    expect(poodles).to.be.true
+  })
+})

--- a/test/utils/fixtures.js
+++ b/test/utils/fixtures.js
@@ -127,7 +127,7 @@ exports.bootstrap = async (wallet, trustedNodes = [], voteReward = '1000') => {
     wallet,
     'EcoBootstrap',
     await wallet.getAddress(),
-    6
+    7
   )
 
   // ### Stage 2
@@ -328,11 +328,18 @@ exports.deployPeripheralContracts = async (
     eco.address
   )
 
-  const ecoXStaking = await deployFrom(
+  const ecoXStakingImpl = await deployFrom(
     wallet,
     'ECOxStaking',
     policyProxy.address,
     ecox.address
+  )
+  await bindProxy(bootstrap, ecoXStakingImpl, 6)
+  const ecoXStaking = await ethers.getContractAt(
+    'ECOxStaking',
+    (
+      await getPlaceholder(bootstrap, 6)
+    ).address
   )
 
   const currencyTimerImpl = await deployFrom(

--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -750,8 +750,8 @@ async function deployStage3(options) {
     options.bootstrap.placeholders[4])
   const trustedNodesProxyAddress = (options.trustedNodesAddress =
     options.bootstrap.placeholders[5])
-    const ecoXStakingProxyAddress = (options.ecoXStakingAddress =
-      options.bootstrap.placeholders[6])
+  const ecoXStakingProxyAddress = (options.ecoXStakingAddress =
+    options.bootstrap.placeholders[6])
 
   // identifier hashes
   const ecoHash = ethers.utils.solidityKeccak256(['string'], ['ECO'])

--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -57,8 +57,8 @@ const ECOxArtifact = require(`../artifacts/contracts/currency/ECOx.sol/ECOx.json
 /* eslint-enable import/no-unresolved */
 
 async function parseFlags(options) {
-  // The protocol currently requires 6 proxies for deployment
-  options.numPlaceholders = '6'
+  // The protocol currently requires 7 proxies for deployment
+  options.numPlaceholders = '7'
 
   if (!options.gasMultiplier) {
     options.gasMultiplier = 5
@@ -750,6 +750,8 @@ async function deployStage3(options) {
     options.bootstrap.placeholders[4])
   const trustedNodesProxyAddress = (options.trustedNodesAddress =
     options.bootstrap.placeholders[5])
+    const ecoXStakingProxyAddress = (options.ecoXStakingAddress =
+      options.bootstrap.placeholders[6])
 
   // identifier hashes
   const ecoHash = ethers.utils.solidityKeccak256(['string'], ['ECO'])
@@ -870,7 +872,7 @@ async function deployStage3(options) {
   if (options.verbose) {
     console.log('deploying the ECOx staking contract...')
   }
-  const ecoXStaking = await ecoXStakingFactory.deploy(
+  const ecoXStakingImpl = await ecoXStakingFactory.deploy(
     policyProxyAddress,
     ecoXAddress,
     { gasPrice }
@@ -977,7 +979,7 @@ async function deployStage3(options) {
     )
   }
   process.stdout.write('Progress: [             ]\r')
-  let receipt = await ecoXStaking.deployTransaction.wait()
+  let receipt = await ecoXStakingImpl.deployTransaction.wait()
   options.gasUsed = receipt.gasUsed.add(options.gasUsed)
   process.stdout.write('Progress: [x            ]\r')
   receipt = await rootHashProposalImpl.deployTransaction.wait()
@@ -1093,6 +1095,25 @@ async function deployStage3(options) {
     }
   )
 
+  if (options.verbose) {
+    console.log(
+      'binding proxy 6 to ECOx staking contract...',
+      ecoXStakingProxyAddress,
+      ecoXStakingImpl.address
+    )
+  }
+  const ecoXStakingProxy = new ethers.Contract(
+    ecoXStakingProxyAddress,
+    EcoInitializableArtifact.abi,
+    options.signer
+  )
+  const ecoXStakingFuseTx = await ecoXStakingProxy.fuseImplementation(
+    ecoXStakingImpl.address,
+    {
+      gasPrice,
+    }
+  )
+
   // policy init inputs
   const identifiers = [
     ecoHash,
@@ -1105,7 +1126,7 @@ async function deployStage3(options) {
   const addresses = [
     ecoAddress,
     ecoXAddress,
-    ecoXStaking.address,
+    ecoXStakingProxyAddress,
     currencyTimerProxyAddress,
     timedPoliciesProxyAddress,
     trustedNodesProxyAddress,
@@ -1147,7 +1168,6 @@ async function deployStage3(options) {
   )
 
   // store relevant addresses in options for output
-  options.ecoXStakingAddress = ecoXStaking.address
   options.rootHashProposalAddress = rootHashProposalImpl.address
   options.vdfAddress = vdfImpl.address
   options.randomInflationAddress = randomInflationImpl.address
@@ -1166,6 +1186,8 @@ async function deployStage3(options) {
   receipt = await timedPoliciesFuseTx.wait()
   options.gasUsed = receipt.gasUsed.add(options.gasUsed)
   receipt = await trustedNodesFuseTx.wait()
+  options.gasUsed = receipt.gasUsed.add(options.gasUsed)
+  receipt = await ecoXStakingFuseTx.wait()
   options.gasUsed = receipt.gasUsed.add(options.gasUsed)
   receipt = await policyFuseTx.wait()
   options.gasUsed = receipt.gasUsed.add(options.gasUsed)


### PR DESCRIPTION
Two bugs were found via our Immunefi bug bounty.

1) When using `delegateAmount` on an attacker address who has (or later sets) a primary delegate, the attacker could self transfer to cause the voting power given by `delegateAmount` to be transferred to the primary delegate. This not only violated the principles of delegation, but disallowed the victim from calling `undelegate` in any form, leaving the amount untransferable. The offending code was in `_afterTokenTransfer` in `VoteCheckpoints.sol` which used `_balances[from] + amount` to calculate the pre-transfer balance of `from`.

This issue was fixed by an early exit of `_afterTokenTransfer` on self transfers as there would be no need to re-calculate delegation. We acknowledge that this would allow a user to self transfer funds that would not be transferrable to any other address (in the case of them being locked by using `delegateAmount`), as this would have no effect on our system.

2) If an attacker is able to sandwich the `incrementGeneration` call, they would have access to the new clone of `PolicyProposals.sol` for that generation in a block that was equal to `blockNumber` where the voting power is measured. This would allow the user to submit a proposal, support it, transfer tokens to another address, and then support it again with the same tokens. This process could be extended as far as gas and contract size limits would allow for the sandwich transaction. This attack is detailed in the humorously named test contract `InfiniteVote.sol`.

This issue was fixed by restricting the voting calculation. Two offending functions created this vulnerability: `getPastVotingGons` and `getPastTotalSupply`. These functions are used in `VotingPower.sol` to determine voting power during the community governance process. They were changed to respect their respective names and require the block submitted to be strictly before the current block. This means that any attempts to perform the exploit above will fail in the calculation of the addresses' voting power. If someone did want to see voting power for the current block, they could use `getVotingGons` or `totalSupply`. Note that `getPastLinearInflation` was not changed in this update as it did not have a corresponding function for the current block and therefore got used in a number of places to access the amount of linear inflation in the current block. We apologize for the naming here.


These issues were addressed in generation 1002 via the proposal `VoteCheckpointsUpgrade.propo.sol` whose deployment can be found here: https://etherscan.io/address/0xd24a6bbc62f5210f41415ed62621f5db21885ad5#code