### PR TITLE
EGP #005 InflationRootHashProposal Upgrade 2 

### DIFF
--- a/contracts/governance/community/proposals/IRHPUpgrade.propo.sol
+++ b/contracts/governance/community/proposals/IRHPUpgrade.propo.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../../policy/Policy.sol";
+import "../../../policy/Policed.sol";
+import "./Proposal.sol";
+import "../../CurrencyTimer.sol";
+
+/** @title IRHPUpgrade
+ * A proposal to update the InflationRootHashProposal implementation
+ */
+contract IRHPUpgrade is Policy, Proposal {
+    /** The address of the updated InflationRootHashProposals contract
+     */
+    address public immutable newIRHP;
+
+    /** The address of the switcher contract for RandomInflation
+     * This contract has setter functions and the right storage layout
+     */
+    address public immutable switcherRandomInflation;
+
+    // The ID hash for CurrencyTimer
+    bytes32 public constant CURRENCY_TIMER_ID = keccak256("CurrencyTimer");
+
+    /** Instantiate a new proposal.
+     *
+     * @param _newIRHP The address of the updated InflationRootHashProposal contract
+     * @param _switcherRandomInflation The address of the switcher contract for RandomInflation
+     */
+    constructor(address _newIRHP, address _switcherRandomInflation) {
+        newIRHP = _newIRHP;
+        switcherRandomInflation = _switcherRandomInflation;
+    }
+
+    /** The name of the proposal.
+     */
+    function name() public pure override returns (string memory) {
+        return "EGP #005 InflationRootHashProposal Upgrade 2";
+    }
+
+    /** A description of what the proposal does.
+     */
+    function description() public pure override returns (string memory) {
+        return
+            "This proposal patches an issue with the Inflation Root Hash Proposal";
+    }
+
+    /** A URL where more details can be found.
+     */
+    function url() public pure override returns (string memory) {
+        return "https://forums.eco.org/t/egp-005-inflationroothashproposal-upgrade-2/";
+    }
+
+    /** This is executed in the storage context of the root policy contract.
+     */
+    function enacted(address self) public override {
+        CurrencyTimer _currencyTimer = CurrencyTimer(
+            policyFor(CURRENCY_TIMER_ID)
+        );
+        address _randomInflation = address(_currencyTimer.inflationImpl());
+
+        Policed(_randomInflation).policyCommand(
+            switcherRandomInflation,
+            abi.encodeWithSignature("setIRHPImpl(address)", newIRHP)
+        );
+    }
+}

--- a/contracts/governance/monetary/InflationRootHashProposal.sol
+++ b/contracts/governance/monetary/InflationRootHashProposal.sol
@@ -21,6 +21,7 @@ contract InflationRootHashProposal is PolicedUtils, TimeUtils {
     }
 
     enum RootHashStatus {
+        Uninitialized,
         Pending,
         Rejected,
         Accepted
@@ -215,6 +216,7 @@ contract InflationRootHashProposal is PolicedUtils, TimeUtils {
         require(!proposal.initialized, "Root hash already proposed");
 
         proposal.initialized = true;
+        proposal.status = RootHashStatus.Pending;
         proposal.rootHash = _proposedRootHash;
         proposal.totalSum = _totalSum;
         proposal.amountOfAccounts = _amountOfAccounts;
@@ -507,6 +509,7 @@ contract InflationRootHashProposal is PolicedUtils, TimeUtils {
      */
     function checkRootHashStatus(address _proposer) external {
         RootHashProposal storage proposal = rootHashProposals[_proposer];
+        require(proposal.initialized, "No such proposal");
 
         if (
             acceptedRootHash == 0 &&
@@ -563,13 +566,15 @@ contract InflationRootHashProposal is PolicedUtils, TimeUtils {
      */
     function claimFeeFor(address _who, address _proposer) public {
         RootHashProposal storage proposal = rootHashProposals[_proposer];
-        InflationChallenge storage challenge = proposal.challenges[_who];
+        require(proposal.initialized, "No such proposal");
         require(
             proposal.status != RootHashStatus.Pending,
-            "Can't claim _fee on pending root hash proposal"
+            "Cannot claimFee on pending proposal"
         );
 
         require(!proposal.claimed[_who], "fee already claimed");
+
+        InflationChallenge storage challenge = proposal.challenges[_who];
 
         if (_who == _proposer) {
             require(

--- a/supervisor/inflationGovernor.ts
+++ b/supervisor/inflationGovernor.ts
@@ -440,7 +440,7 @@ export class InflationGovernor {
             const rhp = await this.inflationRootHashProposal.rootHashProposals(
               supervisorAddress
             )
-            console.log(`expected status = 2, got ${rhp.status}`)
+            console.log(`expected status = 3, got ${rhp.status}`)
           }
         } catch (e) {
           // error logging

--- a/test/governance/InflationRootHashProposal.js
+++ b/test/governance/InflationRootHashProposal.js
@@ -1021,6 +1021,31 @@ describe('InflationRootHashProposal', () => {
             )
         ).to.be.revertedWith('The policy address not allowed in Merkle tree')
       })
+
+      it('cannot checkRootHashStatus for uninitialized root hash', async () => {
+        const unproposedAccount = await accounts[4].getAddress()
+        await expect(
+          rootHashProposal.checkRootHashStatus(unproposedAccount)
+        ).to.be.revertedWith('No such proposal')
+        const proposal = await rootHashProposal.rootHashProposals(
+          unproposedAccount
+        )
+        expect(proposal.status === 0).to.be.true
+        expect(!proposal.initialized).to.be.true
+      })
+
+      it('cannot claimFee for uninitialized proposals', async () => {
+        const unproposedAccount = await accounts[4].getAddress()
+        await expect(
+          rootHashProposal.claimFee(unproposedAccount)
+        ).to.be.revertedWith('No such proposal')
+      })
+
+      it('cannot claimFee for uninitialized proposals', async () => {
+        await expect(
+          rootHashProposal.claimFee(await accounts[0].getAddress())
+        ).to.be.revertedWith('Cannot claimFee on pending proposal')
+      })
     })
 
     context('verify challenge white box testing', async () => {


### PR DESCRIPTION
This proposal patches a bug in Random Inflation and adds more robust checks around claiming proposal fees when submitting Random Inflation.

Summary

The vulnerability patched is in the InflationRootHashProposal.sol contract that oversees the process of submitting the Merkle tree for distributing rewards for Random inflation. A submission on Immunefi alerted us to an issue in the checkRootHashStatus method, which is intended to be used to mark a root hash proposal as being accepted after the challenge period has ended. The bug indicated that the status of an address’ root hash proposal could be locked in before the proposal was submitted. This would cause any challenges to this malicious Merkle tree to revert. The submission of a malicious root hash after this status check would jeopardize the integrity of the random inflation process, and subvert the checks put in place to make it equitable. The fix we implemented demands that the input address to checkRootHashStatus has properly submitted a root hash proposal, and causes other calls to the method to fail. We also reinforced similar checks on other methods, such as claimFee.