### PR TITLE
Add 'name', 'description' and 'url' fields to the constructor of the AccessRootPolicyFunds contract

### DIFF
--- a/contracts/governance/community/proposals/AccessRootPolicyFunds.propo.sol
+++ b/contracts/governance/community/proposals/AccessRootPolicyFunds.propo.sol
@@ -18,28 +18,26 @@ contract AccessRootPolicyFunds is Policy, Proposal {
 
     uint256 public immutable ecoXAmount;
 
+    string public name;
+
+    string public description;
+
+    string public url;
+
     constructor(
         address _recipient,
         uint256 _ecoAmount,
-        uint256 _ecoXAmount
+        uint256 _ecoXAmount,
+        string memory _name,
+        string memory _description,
+        string memory _url
     ) {
         recipient = _recipient;
         ecoAmount = _ecoAmount;
         ecoXAmount = _ecoXAmount;
-    }
-
-    function name() public pure override returns (string memory) {
-        return "Root Policy Funds Use Template";
-    }
-
-    function description() public pure override returns (string memory) {
-        return
-            "Sends ecoAmount and ecoXAmount of ECO and ECOx respectively to recipient";
-    }
-
-    function url() public pure override returns (string memory) {
-        return
-            "https://description.of.proposal make this link to a discussion what the funds are used for";
+        name = _name;
+        description = _description;
+        url = _url;
     }
 
     function enacted(address) public override {

--- a/test/governance/AccessRootPolicyFunds.js
+++ b/test/governance/AccessRootPolicyFunds.js
@@ -59,7 +59,10 @@ describe('E2E Test to access funds in treasury [@group=2]', () => {
         'AccessRootPolicyFunds',
         await charlie.getAddress(),
         500,
-        200
+        200,
+        "Root Policy Funds Use Template",
+        "Sends ecoAmount and ecoXAmount of ECO and ECOx respectively to recipient",
+        "https://description.of.proposal make this link to a discussion what the funds are used for"
       )
       const name = await accessRootPolicyFunds.name()
       expect(name).to.equal('Root Policy Funds Use Template')

--- a/test/governance/AccessRootPolicyFunds.js
+++ b/test/governance/AccessRootPolicyFunds.js
@@ -60,9 +60,9 @@ describe('E2E Test to access funds in treasury [@group=2]', () => {
         await charlie.getAddress(),
         500,
         200,
-        "Root Policy Funds Use Template",
-        "Sends ecoAmount and ecoXAmount of ECO and ECOx respectively to recipient",
-        "https://description.of.proposal make this link to a discussion what the funds are used for"
+        'Root Policy Funds Use Template',
+        'Sends ecoAmount and ecoXAmount of ECO and ECOx respectively to recipient',
+        'https://description.of.proposal make this link to a discussion what the funds are used for'
       )
       const name = await accessRootPolicyFunds.name()
       expect(name).to.equal('Root Policy Funds Use Template')


### PR DESCRIPTION
### Checklist
<!-- 
  Don't edit or delete this section, instead tick the boxes after you have submitted your issue.
  Make sure you comply with the checklist (don't just tick boxes, actually confirm the statements) even if you're submitting a draft PR!
  Make sure you fil out the Details section below the checklist, don't just submit code with no explanation.
-->

 * [x] I am changing solidity code:
   - [x] I have included a proposal that implements the changes I have made or marked this PR as draft
     - [x] I have included an end-to-end test that tests this proposed change and shows that it is implemented correctly
   - [x] I have added and/or modified tests to give 100% branch coverage of the new code, including reverts
   - [x] I have run the formatter (prettier and linter) and have corrected all errors
   - [x] I have updated the documentation (natspec function comments and README files) to fully address my changes
   - [x] The full test suite passes (not just the tests you changed or added)
 * [ ] I am adding a new solidity contract:
   - [ ] I have extensively justified in the Details section below why my code needs to be in this repository instead of its own one.
   - [ ] I have checked every checkbox in the section on changing solidity code
 * [ ] I am adding/changing node code:
   - [ ] I have extensively justified in the Details section below why my code needs to be in this repository instead of its own one.
   - [ ] I have run the formatter (prettier and linter) and have corrected all errors
   - [ ] The full test suite passes (not just the tests related to what you changed or added)

### Details
This change adds 'name', 'description' and 'url' fields to the constructor of the AccessRootPolicyFunds contract, removing the need to edit the contract code in order to use it. Now, anyone can deploy a complete and descriptive request for funds proposal simply by providing the correct constructor arguments.